### PR TITLE
Remove empty strings as valid

### DIFF
--- a/src/screens/poa-form/index.js
+++ b/src/screens/poa-form/index.js
@@ -161,7 +161,9 @@ class PoAForm extends React.Component {
   stepErrors() {
     const validators = [
       {
-        childrenNames: () => this.state.childrenNames.length !== this.state.numberOfChildren
+        childrenNames: () => {
+          return this.state.childrenNames.filter(n => !!n).length !== this.state.numberOfChildren
+        }
       },
       {
         motherAddress: () => this.validateAddress(this.state.motherAddress),

--- a/src/screens/poa-form/index.js
+++ b/src/screens/poa-form/index.js
@@ -162,6 +162,7 @@ class PoAForm extends React.Component {
     const validators = [
       {
         childrenNames: () => {
+          // Only non-empty child names are valid 
           return this.state.childrenNames.filter(n => !!n).length !== this.state.numberOfChildren
         }
       },


### PR DESCRIPTION
A user can add a name, then delete it, then proceed without errors. This fixes that. 