### PR TITLE
Deploy our build/ folder to gh-pages via travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,6 @@ deploy:
   skip-cleanup: true
   github-token: $GITHUB_TOKEN
   keep-history: true
+  local-dir: build
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
 script:
   - yarn lint
   - yarn test
+before_deploy:
   - yarn build
 deploy:
   provider: pages


### PR DESCRIPTION
This just adds the [`local-dir` option](https://docs.travis-ci.com/user/deployment/pages/#Further-configuration) to deploy our build file (created by `yarn build`) to `gh-pages`.