### PR TITLE
fix state picker bug

### DIFF
--- a/src/screens/poa-form/styles.scss
+++ b/src/screens/poa-form/styles.scss
@@ -23,14 +23,18 @@
   }
 }
 
-.grommetux-text-input.grommetux-input.input-class,
-.grommetux-select {
+.grommetux-text-input.grommetux-input.input-class {
   margin: 0 1em 1em 0;
 }
 
 .grommetux-select,
 .grommetux-select__drop {
   width: 200px;
+}
+
+// Prevent "Select" button and dropdown from sticking
+.grommetux-select .grommetux-button {
+  padding: 0px 0rem !important;
 }
 
 .grommetux-box.grommetux-box--direction-row.grommetux-box--justify-end.grommetux-box--flex.grommetux-box--pad-none.download-container {
@@ -82,4 +86,3 @@
     display: none;
   }
 }
-


### PR DESCRIPTION
Custom styling on the grommit "Button" class broke the styling on the little button inside the state picker. If that button is given custom margin or padding, then the whole dropdown menu sticks. I solved this by removing margin and padding from that "Select" button subclass.

https://github.com/code-for-nashville/power-of-attorney/issues/51