### PR TITLE
WIP Browser compat fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "homepage": "http://immigrantpoa.org/",
   "private": true,
   "dependencies": {
+    "core-js": "^2.5.7",
     "grommet": "^1.10.1",
     "i18next": "^11.2.3",
     "i18next-browser-languagedetector": "^2.2.0",
@@ -11,6 +12,7 @@
     "node-sass-chokidar": "^1.2.2",
     "pdfmake": "^0.1.36",
     "prettier": "1.12.1",
+    "raf": "^3.4.0",
     "react": "^16.3.1",
     "react-async-component": "^2.0.0",
     "react-dom": "^16.3.1",

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="theme-color" content="#000000">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
   <meta property="og:url"                content="https://immigrantpoa.org" />
   <meta property="og:type"               content="website" /> 
   <meta property="og:title"              content="Immigrant Power of Attorney" />
@@ -29,6 +31,13 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
   <title>Power of Attorney</title>
+
+  <!--[if lt IE 9]>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/es5-shim/4.5.7/es5-shim.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/es5-shim/4.5.7/es5-sham.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
+  <![endif]-->
+
 </head>
 
 <body>

--- a/src/helpers/i18n.js
+++ b/src/helpers/i18n.js
@@ -5,7 +5,8 @@ import spanish from '../strings/spanish'
 
 i18n.use(LanguageDetector).init({
   fallbackLng: 'en',
-  debug: process.env.NODE_ENV !== 'production',
+  // debug: process.env.NODE_ENV !== 'production',
+  debug: false,
   // react i18next special options (optional) https://react.i18next.com/components/i18next-instance
   react: {
     wait: false,
@@ -31,7 +32,8 @@ i18n.addResourceBundle('es', 'translation', spanish)
 
 export const getCurrentLanguage = () => {
   // English and Spanish are currently the only supported languages
-  if (i18n.language && i18n.language.includes('es')) {
+  // bitwise shifts -1 to 0, all else to not 0
+  if (i18n.language && i18n.language.indexOf('es') >= 0) {
     return 'es'
   }
   return 'en'

--- a/src/helpers/i18n.js
+++ b/src/helpers/i18n.js
@@ -32,7 +32,6 @@ i18n.addResourceBundle('es', 'translation', spanish)
 
 export const getCurrentLanguage = () => {
   // English and Spanish are currently the only supported languages
-  // bitwise shifts -1 to 0, all else to not 0
   if (i18n.language && i18n.language.indexOf('es') >= 0) {
     return 'es'
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,8 @@
+// polyfills
+import 'raf/polyfill'
+import 'core-js/es6/map'
+import 'core-js/es6/set'
+
 import React from 'react'
 import ReactDOM from 'react-dom'
 


### PR DESCRIPTION
* Polyfills - https://reactjs.org/docs/javascript-environment-requirements.html 
* HTML5 shiv - https://stackoverflow.com/questions/29828561/react-js-not-working-with-internet-explorer-9
* Additionally targeting contemporary document rendering mode for older IE - `<meta http-equiv="X-UA-Compatible" content="IE=edge">`
* Shim/sham - https://github.com/es-shims/es5-shim
* [IE doesn't support `includes`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes#Browser_compatibility)
* i18n uses methods on the `console` object that aren't supported in IE9 https://github.com/i18next/react-i18next/issues/455