### PR TITLE
Fix child name error

### DIFF
--- a/src/components/address/index.js
+++ b/src/components/address/index.js
@@ -37,7 +37,7 @@ export class AddressComponent extends Component<
   ) => {
     const addressType = e.target.dataset.addressType
     let value = e.option ? e.option.value : e.target.value
-    console.log({value, addressType})
+
     if (addressType === 'postal_code') {
       value = value.slice(0, 5)
     }
@@ -46,7 +46,7 @@ export class AddressComponent extends Component<
 
   render() {
     const {address, errors, name, t} = this.props
-    console.log({address})
+
     return (
       <Box margin={{vertical: 'medium'}}>
         <FormField

--- a/src/components/form-subjects/index.js
+++ b/src/components/form-subjects/index.js
@@ -55,10 +55,13 @@ class FormSubjects extends Component<
   }
 
   render() {
-    const {t} = this.props
+    const {t, error} = this.props
     return (
       <Box>
-        <FormField label={t('numberOfChildren')}>
+        <FormField 
+          label={t('numberOfChildren')}
+          error={error ? t('pleaseAddChildName') : null}
+        >
           <NumberInput
             min={1}
             onChange={this.onNumberOfSubjectsChange}

--- a/src/components/form-subjects/index.js
+++ b/src/components/form-subjects/index.js
@@ -58,7 +58,7 @@ class FormSubjects extends Component<
     const {t, error} = this.props
     return (
       <Box>
-        <FormField 
+        <FormField
           label={t('numberOfChildren')}
           error={error ? t('pleaseAddChildName') : null}
         >

--- a/src/screens/poa-form/index.js
+++ b/src/screens/poa-form/index.js
@@ -170,7 +170,6 @@ class PoAForm extends Component<PoAFormProps, PoAFormState> {
       of the fields failed validation.
   */
   stepErrors(): Object {
-    const {t} = this.props
     const validators = [
       {
         // Only non-empty child names are valid

--- a/src/screens/poa-form/index.js
+++ b/src/screens/poa-form/index.js
@@ -177,8 +177,6 @@ class PoAForm extends Component<PoAFormProps, PoAFormState> {
         childrenNames: () =>
           this.state.childrenNames.filter(n => !!n).length !==
           this.state.numberOfChildren
-            ? t('pleaseAddChildName')
-            : ''
       },
       {
         motherAddress: () => this.validateAddress(this.state.motherAddress),


### PR DESCRIPTION
Fix recursive error with child name error. 
Instead of setting the error key value as a boolean it was being set as the error message string.

The solution was to set it as a boolean, pass that value to the form component where the error message is displayed if it is true.

Closes issue #109 