### PR TITLE
Move build to script phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "8"
+  - "12"
 cache:
   yarn: true
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ script:
   - yarn lint
   - yarn test
   - yarn flow
-before_deploy:
   - yarn build
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "12"
+  - "8"
 cache:
   yarn: true
   directories:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "power-of-attorney",
   "version": "0.1.0",
   "homepage": "http://immigrantpoa.org/",
-  "private": true,
+  "private": false,
+  "engines": {
+    "node": "12.13.0"
+  },
   "dependencies": {
     "core-js": "^2.5.7",
     "grommet": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "http://immigrantpoa.org/",
   "private": false,
   "engines": {
-    "node": "12.13.0"
+    "node": "8"
   },
   "dependencies": {
     "core-js": "^2.5.7",


### PR DESCRIPTION
We were only running `yarn build` before deploy, since we only deploy master we wouldn't get a failure merging into other branches.

Moving this command to the `script` phase will run it on every branch so we will know before merging to master if branch will fail to build.

The PR also defines node 8 as the engine in the `package.json`. Also sets private to false in the `package.json`