### PR TITLE
Adding general error message on validation failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log*
 # css
 src/**/*.css
 
+.vscode/settings.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,12 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "command": "REACT_APP_MOCK_FORM=true yarn start",
+      "name": "Start dev server with mock form data",
+      "request": "launch",
+      "type": "node-terminal"
+    },
+    {
       "name": "Chrome",
       "type": "chrome",
       "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,12 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "command": "yarn test",
+      "name": "Run and watch all tests",
+      "request": "launch",
+      "type": "node-terminal"
+    },
+    {
       "command": "REACT_APP_MOCK_FORM=true yarn start",
       "name": "Start dev server with mock form data",
       "request": "launch",

--- a/src/screens/poa-form/defaultState.js
+++ b/src/screens/poa-form/defaultState.js
@@ -9,7 +9,10 @@ const emptyAddress = {
   postal_code: ''
 }
 const MOCK_FORM = REACT_APP_MOCK_FORM === 'true'
-const FORM_STEP = REACT_APP_FORM_STEP ? parseInt(REACT_APP_FORM_STEP, 10) : 0
+const FORM_STEP = {
+  number: REACT_APP_FORM_STEP ? parseInt(REACT_APP_FORM_STEP, 10) : 0,
+  attempted: false
+}
 
 const mockedAddress = (name: string) => ({
   name,

--- a/src/screens/poa-form/index.js
+++ b/src/screens/poa-form/index.js
@@ -40,7 +40,10 @@ type FormInputErrors = {|
 
 type PoAFormState = {|
   acceptedModal: boolean,
-  step: number,
+  step: {
+    number: number,
+    attempted: boolean
+  },
   numberOfChildren: number,
   submitted: boolean,
   errors: FormInputErrors,
@@ -100,46 +103,59 @@ class PoAForm extends Component<PoAFormProps, PoAFormState> {
   }
 
   _back = () => {
-    if (this.state.step > 0) {
-      this.setState(state => ({step: --state.step}))
+    if (this.state.step.number > 0) {
+      this.setState(state => ({
+        step: {
+          number: state.step.number - 1,
+          attempted: false
+        }
+      }))
     }
   }
 
   /*
-    Recursively check if an object has errors.
+    Recursively check if an error object has errors.
 
     Error objects are expected to have booleans(true/false) or a nested error
     object as values.
   */
-  hasError(object) {
-    return Object.values(object).reduce((result, value) => {
-      if (typeof value === 'boolean') {
-        return result || value
-      }
-      return result || this.hasError(value)
-    }, false)
+  static hasError(errorEntry: boolean | Object): boolean {
+    return PoAForm.errorCount(errorEntry) > 0
+  }
+
+  static errorCount(errorEntry: boolean | Object): number {
+    if (typeof errorEntry === 'boolean') {
+      return errorEntry ? 1 : 0
+    } else if (typeof errorEntry === 'object') {
+      return Object.values(errorEntry).reduce((sum, errorEntry) => sum + PoAForm.errorCount(errorEntry), 0)
+    }
+    return 0
   }
 
   _next = () => {
     const errors = this.stepErrors()
-    if (this.hasError(errors)) {
+    this.setState(state => ({
+      step: {...state.step, attempted: true}
+    }))
+    if (PoAForm.hasError(errors)) {
       this.setState({errors: errors})
     } else {
       if (this.isLastStep()) {
         this.submit()
       } else {
-        this.setState(state => ({step: state.step + 1}))
+        this.setState(state => ({
+          step: {
+            number: state.step.number + 1,
+            attempted: false
+          }
+        }))
         if (typeof window !== 'undefined') window.scrollTo(0, 0)
       }
     }
   }
 
   /*
-    Returns an object containing validation errors for just the current step
-
-    Returns: An Array of two elements. The first element is a key of field names
-      to error objects.  The second element is a boolean that is True if any
-      of the fields failed validation.
+    Returns an object containing validation errors for just the current step.
   */
   stepErrors(): Object {
     const validators = [
@@ -164,7 +180,7 @@ class PoAForm extends Component<PoAFormProps, PoAFormState> {
             ? this.state.parentalStatusReason.length === 0
             : false
       }
-    ][this.state.step]
+    ][this.state.step.number]
 
     const errors = {}
 
@@ -176,7 +192,7 @@ class PoAForm extends Component<PoAFormProps, PoAFormState> {
   }
 
   isLastStep = () => {
-    return this.state.step === 3
+    return this.state.step.number === 3
   }
 
   renderAddress = name => {
@@ -269,7 +285,7 @@ class PoAForm extends Component<PoAFormProps, PoAFormState> {
   }
 
   renderForm() {
-    switch (this.state.step) {
+    switch (this.state.step.number) {
       case 0:
         return this.renderStepOne()
       case 1:
@@ -286,6 +302,31 @@ class PoAForm extends Component<PoAFormProps, PoAFormState> {
   renderDownloadButtons() {
     if (this.state.submitted) {
       return <AsyncDownloadPDF data={this.state} />
+    }
+    return null
+  }
+
+  /*
+    Checks if the step has been attempted. If so, checks to see if there are errors for the current step.
+    If so, renders a box with an error message. Otherwise, returns null.
+   */
+  renderErrorMessage() {
+    if (this.state.step && this.state.step.attempted) {
+      const stepErrorKeys = Object.keys(this.stepErrors())
+      const errors = this.state.errors
+      const errorCount = stepErrorKeys.map(stepErrorKey => errors[stepErrorKey])
+        .map(PoAForm.errorCount)
+        .reduce((sum, errorCount) => sum + errorCount, 0)
+      const {t} = this.props
+      if (errorCount > 0) {
+        return (
+          <Box align="end" className="form-error-message">
+            {t('formWithErrors', {errorCount: errorCount.toString()})}
+            {/* The version of grommet being used doesn't support padding only on one side */}
+            <Box pad={{vertical: "small"}}/>
+          </Box>
+        )
+      }
     }
     return null
   }
@@ -332,13 +373,13 @@ class PoAForm extends Component<PoAFormProps, PoAFormState> {
               activeColor="#679ba1"
               completeColor="#679ba1"
               activeBorderColor="#679ba1"
-              activeStep={this.state.step}
+              activeStep={this.state.step.number}
             />
           </div>
         </div>
 
         <Paragraph className="align-center">
-          <strong>{t('partI')}</strong>
+          <strong>{t('partI')} </strong>
           {t('thisFormIsToBeFilled')}
         </Paragraph>
         <Box direction="row" justify="between">
@@ -346,6 +387,7 @@ class PoAForm extends Component<PoAFormProps, PoAFormState> {
           <Box basis="1/3">
             <Form autoComplete="off" className="align-center">
               <Box pad={{vertical: 'medium'}}>{this.renderForm()}</Box>
+              {this.renderErrorMessage()}
               <Box
                 alignSelf="center"
                 direction="row"
@@ -359,7 +401,7 @@ class PoAForm extends Component<PoAFormProps, PoAFormState> {
                   primary={true}
                   className="button hidden-large"
                   style={
-                    this.state.step === 0
+                    this.state.step.number === 0
                       ? {backgroundColor: 'grey', borderColor: 'grey'}
                       : {}
                   }

--- a/src/screens/poa-form/index.js
+++ b/src/screens/poa-form/index.js
@@ -126,7 +126,7 @@ class PoAForm extends Component<PoAFormProps, PoAFormState> {
   static errorCount(errorEntry: boolean | Object): number {
     if (typeof errorEntry === 'boolean') {
       return errorEntry ? 1 : 0
-    } else if (typeof errorEntry === 'object') {
+    } else if (typeof errorEntry === 'object' && errorEntry !== null) {
       return Object.values(errorEntry).reduce((sum, errorEntry) => sum + PoAForm.errorCount(errorEntry), 0)
     }
     return 0

--- a/src/screens/poa-form/poa-form.spec.js
+++ b/src/screens/poa-form/poa-form.spec.js
@@ -6,3 +6,13 @@ it('renders without crashing', () => {
   const div = document.createElement('div')
   ReactDOM.render(<POAForm />, div)
 })
+
+it('displays an error message when form fields are missing', () => {
+  const div = document.createElement('div')
+  const ref = ReactDOM.render(<POAForm />, div)
+  expect(div.getElementsByClassName("form-error-message").length).toEqual(0)
+
+  ref._next()
+
+  expect(div.getElementsByClassName("form-error-message").length).toEqual(1)
+})

--- a/src/screens/poa-form/styles.scss
+++ b/src/screens/poa-form/styles.scss
@@ -11,6 +11,10 @@
   display: block;
 }
 
+.form-error-message {
+  color: #c00;
+}
+
 .grommetux-text-input.grommetux-input.input-class-long {
   margin: 0 0.5em 1em 0;
   width: 100%;

--- a/src/strings/english.js
+++ b/src/strings/english.js
@@ -15,7 +15,7 @@ const ENGLISH: TranslateStringsType = {
   pleaseAddName: 'Please add a name.',
   streetAddress: 'Street Address',
   pleaseAddCity: 'Please add a city.',
-  pleaseAddState: 'Please add at state.',
+  pleaseAddState: 'Please add a state.',
   city: 'City',
   state: 'State',
   pleaseAddZip: 'Please enter a 5 digit zip code.',


### PR DESCRIPTION
Added text that shows up above the next button when it's pressed and the form has validation errors. I couldn't find a way do determine that the form had been attempted and there were errors with the existing fields in the state, so I added a field to the step state to track if the form has been attempted yet.

GIF of the feature in action:

![errorMessage](https://user-images.githubusercontent.com/5950484/85346748-0b05c400-b4bc-11ea-8c80-ead7d26001ab.gif)

I also made two small changes to add a space after the "Part I" text and fix a typo. Let me know if you'd like me to omit those or update this PR otherwise!